### PR TITLE
bug fix push error sizeof _triSize when serialize

### DIFF
--- a/obbStruct.cpp
+++ b/obbStruct.cpp
@@ -94,7 +94,7 @@ unsigned char* CObbStruct::serialize(int& dataSize) const
 
     data.push_back(3); // ser ver
 
-    pushData(data,&_triSize,sizeof(int));
+    pushData(data,&_triSize,sizeof(double));
     pushData(data,&_triCnt,sizeof(int));
     pushData(data,&_originalVerticesSize,sizeof(int));
     pushData(data,&_originalVerticesHash,sizeof(unsigned long));


### PR DESCRIPTION
when serializing CObbStruct object, it pushes wrong size of data for _triSize